### PR TITLE
use mecab

### DIFF
--- a/braille-ja.gemspec
+++ b/braille-ja.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "mecab", "0.996"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/braille-ja/tokenizer.rb
+++ b/lib/braille-ja/tokenizer.rb
@@ -35,7 +35,7 @@ module BrailleJa
     def each_node(source)
       node = @mecab.parseToNode(source)
       while node
-	yield node
+        yield node
         node = node.next
       end
     end

--- a/lib/braille-ja/tokenizer.rb
+++ b/lib/braille-ja/tokenizer.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require 'MeCab'
+require 'mecab'
 
 module BrailleJa
   class Tokenizer

--- a/spec/braille-ja_spec.rb
+++ b/spec/braille-ja_spec.rb
@@ -10,9 +10,9 @@ describe BrailleJa::Translator do
     expect('あいうえお'.to_braille).to eq '⠁⠃⠉⠋⠊'
   end
 
-  it 'never translates Japanese Kanji but leave as is' do
-    kanji = '半沢直樹倍返'
-    expect(kanji.to_braille).to eq kanji
+  it 'translates Japanese Kanji string easily' do
+    expect('半沢直樹倍返し'.to_braille).to eq 'はんざわなおきばいがえし'.to_braille
+    expect('私は海へ行きたい'.to_braille).to eq 'わたしわうみえいきたい'.to_braille
   end
 
   it 'translates alphabet or number' do


### PR DESCRIPTION
[diasks2/heroku-buildpack-mecab](https://github.com/diasks2/heroku-buildpack-mecab) を使えば heroku で mecab が使えるので、mecab から発音情報を取得するようにしてみました。助詞の「へ」「は」にも対応しています。

デモ: http://tily.github.io/braille-ja/
